### PR TITLE
Deprecate locations/router-scroll for Embers own implementation

### DIFF
--- a/addon/locations/router-scroll.js
+++ b/addon/locations/router-scroll.js
@@ -11,7 +11,7 @@ const uuid = () => 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) =
 export default HistoryLocation.extend({
   pushState(path) {
     deprecate(
-      `If you are overriding ember-router-scroll's implementation of "pushState", then you can import and override a new location object like so: import HistoryLocation from '@ember/routing/history-location';`,
+      `If you are overriding ember-router-scroll's implementation of "pushState", then you can subclass and override a new location object from: import HistoryLocation from '@ember/routing/history-location';`,
       false,
       {
         id: 'ember-router-scroll',
@@ -26,7 +26,7 @@ export default HistoryLocation.extend({
 
   replaceState(path) {
     deprecate(
-      `If you are overriding ember-router-scroll's implementation of "replaceState", then you can import and override a new location object like so: import HistoryLocation from '@ember/routing/history-location';`,
+      `If you are overriding ember-router-scroll's implementation of "replaceState", then you can subclass and override a new location object from: import HistoryLocation from '@ember/routing/history-location';`,
       false,
       {
         id: 'ember-router-scroll',

--- a/addon/locations/router-scroll.js
+++ b/addon/locations/router-scroll.js
@@ -1,5 +1,6 @@
 import HistoryLocation from '@ember/routing/history-location';
 import { set, get } from '@ember/object';
+import { deprecate } from '@ember/application/deprecations';
 
 const uuid = () => 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
   const r = Math.random() * 16 | 0;
@@ -9,12 +10,30 @@ const uuid = () => 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) =
 
 export default HistoryLocation.extend({
   pushState(path) {
+    deprecate(
+      `If you are overriding ember-router-scroll's implementation of "pushState", then you can import and override like so: import HistoryLocation from '@ember/routing/history-location';`,
+      false,
+      {
+        id: 'ember-router-scroll',
+        until: '2.0.0'
+      }
+    );
+
     const state = { path, uuid: uuid() };
     get(this, 'history').pushState(state, null, path);
     set(this, '_previousURL', this.getURL());
   },
 
   replaceState(path) {
+    deprecate(
+      `If you are overriding ember-router-scroll's implementation of "replaceState", then you can import and override like so: import HistoryLocation from '@ember/routing/history-location';`,
+      false,
+      {
+        id: 'ember-router-scroll',
+        until: '2.0.0'
+      }
+    );
+
     const state = { path, uuid: uuid() };
     get(this, 'history').replaceState(state, null, path);
     set(this, '_previousURL', this.getURL());

--- a/addon/locations/router-scroll.js
+++ b/addon/locations/router-scroll.js
@@ -11,7 +11,7 @@ const uuid = () => 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) =
 export default HistoryLocation.extend({
   pushState(path) {
     deprecate(
-      `If you are overriding ember-router-scroll's implementation of "pushState", then you can import and override like so: import HistoryLocation from '@ember/routing/history-location';`,
+      `If you are overriding ember-router-scroll's implementation of "pushState", then you can import and override a new location object like so: import HistoryLocation from '@ember/routing/history-location';`,
       false,
       {
         id: 'ember-router-scroll',
@@ -26,7 +26,7 @@ export default HistoryLocation.extend({
 
   replaceState(path) {
     deprecate(
-      `If you are overriding ember-router-scroll's implementation of "replaceState", then you can import and override like so: import HistoryLocation from '@ember/routing/history-location';`,
+      `If you are overriding ember-router-scroll's implementation of "replaceState", then you can import and override a new location object like so: import HistoryLocation from '@ember/routing/history-location';`,
       false,
       {
         id: 'ember-router-scroll',


### PR DESCRIPTION
Target removal in 2.0

close #193

https://github.com/emberjs/ember.js/blob/master/packages/@ember/-internals/routing/lib/location/history_location.ts#L206