### PR TITLE
Remove ember-getowner-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,8 +66,7 @@
   "dependencies": {
     "ember-app-scheduler": "^1.0.5",
     "ember-cli-babel": "^7.1.2",
-    "ember-compatibility-helpers": "^1.1.2",
-    "ember-getowner-polyfill": "^2.2.0"
+    "ember-compatibility-helpers": "^1.1.2"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3348,19 +3348,6 @@ ember-export-application-global@^2.0.0:
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
 
-ember-factory-for-polyfill@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz#b446ed64916d293c847a4955240eb2c993b86eae"
-  dependencies:
-    ember-cli-version-checker "^2.1.0"
-
-ember-getowner-polyfill@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz#38e7dccbcac69d5ec694000329ec0b2be651d2b2"
-  dependencies:
-    ember-cli-version-checker "^2.1.0"
-    ember-factory-for-polyfill "^1.3.1"
-
 ember-load-initializers@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ember-load-initializers/-/ember-load-initializers-2.0.0.tgz#d4b3108dd14edb0f9dc3735553cc96dadd8a80cb"


### PR DESCRIPTION
ember-getowner-polyfill is not required for Ember 2.3.0 and later. The lowest version of Ember ember-router-scroll supports (and runs tests on in ember-try/Travis) is 2.18.