### PR TITLE
Restore necessary `locationType`

### DIFF
--- a/addon/locations/router-scroll.js
+++ b/addon/locations/router-scroll.js
@@ -13,7 +13,7 @@ export default HistoryLocation.extend({
     this._super(...arguments);
 
     deprecate(
-      `Setting \`locationType: 'router-scroll'\` in config/environment.js is deprecated, please remove it or change it to 'auto'. If you are overriding ember-router-scroll's implementation of "pushState" or "replaceState", then you can subclass and override a new location object from: import HistoryLocation from '@ember/routing/history-location';`,
+      `Setting 'locationType' to 'router-scroll' in config/environment.js is deprecated, please change it to 'auto'. If you are overriding ember-router-scroll's implementation of "pushState" or "replaceState", then you can subclass and override a new location object from: import HistoryLocation from '@ember/routing/history-location';`,
       false,
       {
         id: 'ember-router-scroll',

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -5,6 +5,7 @@ module.exports = function(environment) {
     modulePrefix: 'dummy',
     environment,
     rootURL: '/',
+    locationType: 'auto',
     historySupportMiddleware: true,
     EmberENV: {
       FEATURES: {


### PR DESCRIPTION
My bad, @snewcomer. 😅 This PR restores `locationType` (now it's `auto`) in the dummy config, and tweaks the deprecation notice.

Ember docs say about Router's `location`:
> This value is defaulted to `auto`

…but the later part of that sentence is important… 😉

> (…) by the `locationType` setting of `/config/environment.js`