### PR TITLE
Fix query-params-only transitions

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -60,7 +60,7 @@ let RouterScrollMixin = Mixin.create({
 
     let preserveScrollPosition;
     if (gte('3.6.0-beta.1')) {
-      preserveScrollPosition = getWithDefault(transition, 'intent.router.currentRouteInfos', []).some((routeInfo) => get(routeInfo, 'route.controller.preserveScrollPosition'));
+      preserveScrollPosition = getWithDefault(transition, 'router.currentRouteInfos', []).some((routeInfo) => get(routeInfo, 'route.controller.preserveScrollPosition'));
     } else {
       preserveScrollPosition = transition.some((t) => get(t, 'handler.controller.preserveScrollPosition'));
     }

--- a/tests/acceptance/basic-functionality-test.js
+++ b/tests/acceptance/basic-functionality-test.js
@@ -3,8 +3,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import {
   visit,
   click,
-  currentURL,
-  triggerEvent
+  currentURL
 } from '@ember/test-helpers';
 import config from 'dummy/config/environment';
 
@@ -14,6 +13,7 @@ module('Acceptance | basic functionality', function(hooks) {
   hooks.beforeEach(function() {
     document.getElementById('ember-testing-container').scrollTop = 0;
   });
+
   hooks.afterEach(function() {
     config['routerScroll'] = {};
   });
@@ -30,12 +30,9 @@ module('Acceptance | basic functionality', function(hooks) {
     assert.equal(container.scrollTop, 0);
 
     document.getElementById('monster').scrollIntoView(false);
-    await triggerEvent(window, 'scroll');
-
     assert.ok(container.scrollTop > 0);
 
     await click('a[href="/next-page"]');
-
     assert.equal(currentURL(), '/next-page');
   });
 
@@ -54,7 +51,6 @@ module('Acceptance | basic functionality', function(hooks) {
     assert.ok(container.scrollTop > 0);
 
     await click('a[href="/target-next-page"]');
-
     assert.equal(currentURL(), '/target-next-page');
   });
 });

--- a/tests/acceptance/basic-functionality-test.js
+++ b/tests/acceptance/basic-functionality-test.js
@@ -53,4 +53,21 @@ module('Acceptance | basic functionality', function(hooks) {
     await click('a[href="/target-next-page"]');
     assert.equal(currentURL(), '/target-next-page');
   });
+
+  test('The application should work when just changing query params', async function(assert) {
+    config['routerScroll'] = {
+      scrollElement: '#ember-testing-container'
+    }
+
+    await visit('/');
+
+    let container = document.getElementById('ember-testing-container');
+    assert.equal(container.scrollTop, 0);
+
+    document.getElementById('monster').scrollIntoView(false);
+    assert.ok(container.scrollTop > 0);
+
+    await click('#change-size');
+    assert.ok(container.scrollTop > 0);
+  });
 });

--- a/tests/acceptance/basic-functionality-test.js
+++ b/tests/acceptance/basic-functionality-test.js
@@ -29,7 +29,7 @@ module('Acceptance | basic functionality', function(hooks) {
     let container = document.getElementById('ember-testing-container');
     assert.equal(container.scrollTop, 0);
 
-    await document.getElementById('monster').scrollIntoView(false);
+    document.getElementById('monster').scrollIntoView(false);
     await triggerEvent(window, 'scroll');
 
     assert.ok(container.scrollTop > 0);
@@ -50,7 +50,7 @@ module('Acceptance | basic functionality', function(hooks) {
     let container = document.getElementById('ember-testing-container');
     assert.equal(container.scrollTop, 0);
 
-    await document.getElementById('monster').scrollIntoView(false);
+    document.getElementById('monster').scrollIntoView(false);
     assert.ok(container.scrollTop > 0);
 
     await click('a[href="/target-next-page"]');

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,0 +1,6 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  queryParams: ['small', 'preserveScrollPosition'],
+  small: false
+});

--- a/tests/dummy/app/helpers/not.js
+++ b/tests/dummy/app/helpers/not.js
@@ -1,0 +1,7 @@
+import Helper from '@ember/component/helper';
+
+export default Helper.extend({
+  compute([value]) {
+    return !value;
+  }
+});

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -56,6 +56,18 @@ div {
   margin: 12% 10% -200px 10%;
 }
 
+#change-size {
+  bottom: 0;
+  color: white;
+  padding: 16px;
+  position: fixed;
+  right: 0;
+}
+
+.small {
+  transform: scale(0.5);
+}
+
 #nav {
   height: 44px;
   background-color: white;

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -2,7 +2,15 @@
   <div id="intro">
     Click on the submarine to launch!
   </div>
-  {{#link-to "next-page"}}<img src="/images/yellow_submarine.gif" alt="Submarine" id="submarine">{{/link-to}}
+
+  {{#link-to "application" (query-params small=(not this.small) preserveScrollPosition=true) id="change-size"}}
+    Click here to change the size of the submarine
+  {{/link-to}}
+
+  {{#link-to "next-page"}}
+    <img src="/images/yellow_submarine.gif" alt="Submarine" id="submarine" class={{if this.small "small"}}>
+  {{/link-to}}
+
   <div class="depth left">
     — 500 fathoms
   </div>

--- a/tests/unit/mixins/router-scroll-test.js
+++ b/tests/unit/mixins/router-scroll-test.js
@@ -28,18 +28,16 @@ module('mixin:router-scroll', function(hooks) {
           preserveScrollPosition: isPreserveScroll || false
         }
       },
-      intent: {
-        router: {
-          currentRouteInfos: [
-            {
-              route: {
-                controller: {
-                  preserveScrollPosition: isPreserveScroll || false
-                }
+      router: {
+        currentRouteInfos: [
+          {
+            route: {
+              controller: {
+                preserveScrollPosition: isPreserveScroll || false
               }
             }
-          ]
-        }
+          }
+        ]
       }
     };
 


### PR DESCRIPTION
Using `preserveScrollPosition` option didn't have any effect on transitions that were changing only query params.