### PR TITLE
Update readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ ember-router-scroll
 ==============================================================================
 
 [![Build Status](https://travis-ci.org/DockYard/ember-router-scroll.svg?branch=master)](https://travis-ci.org/DockYard/ember-router-scroll)
-[![Greenkeeper badge](https://badges.greenkeeper.io/dollarshaveclub/ember-router-scroll.svg)](https://greenkeeper.io/)
 
 > Scroll to page top on transition, like a non-SPA website. An alternative scroll behavior for Ember applications.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ember-router-scroll
 ==============================================================================
 
-[![Build Status](https://travis-ci.org/dollarshaveclub/ember-router-scroll.svg?branch=master)](https://travis-ci.org/dollarshaveclub/ember-router-scroll)
+[![Build Status](https://travis-ci.org/DockYard/ember-router-scroll.svg?branch=master)](https://travis-ci.org/DockYard/ember-router-scroll)
 [![Greenkeeper badge](https://badges.greenkeeper.io/dollarshaveclub/ember-router-scroll.svg)](https://greenkeeper.io/)
 
 > Scroll to page top on transition, like a non-SPA website. An alternative scroll behavior for Ember applications.


### PR DESCRIPTION
Looks like `ember-router-scroll` is no longer using Greenkeeper?