### PR TITLE
Allow recording position with users first page visit

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -96,7 +96,6 @@ let RouterScrollMixin = Mixin.create({
 
     if (get(this, 'service.isFirstLoad')) {
       get(this, 'service').unsetFirstLoad();
-      return;
     }
 
     let scrollPosition;


### PR DESCRIPTION
Ref #55 

We want the `routeDidChange` semantics to run its course on first page load so to create a "history" item that allows back button to go to the correct location.

close #173 