### PR TITLE
Update homepage in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "bugs": {
     "url": "https://github.com/dockyard/ember-router-scroll/issues"
   },
-  "homepage": "https://dollarshaveclub.github.io/ember-router-scroll/",
+  "homepage": "https://github.com/DockYard/ember-router-scroll",
   "scripts": {
     "build": "ember build",
     "lint:hbs": "ember-template-lint .",


### PR DESCRIPTION
The currently linked URL does not work any longer. This changes the homepage to the GitHub page, which seems to be appropriate and quite common across other Ember addons.