### PR TITLE
[BUG] update scroll position should only be called once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 3.1.3
+* [#242](https://github.com/DockYard/ember-router-scroll/pull/242) Unique functions to scheduleOnce...follow up
+* [#241](https://github.com/DockYard/ember-router-scroll/pull/241) Prevent multiple calls on routeDidChange
+* [#240](https://github.com/DockYard/ember-router-scroll/pull/240) Missing setter for scrollWhenAfterRender
+
+## 3.1.0
+* [#239](https://github.com/DockYard/ember-router-scroll/pull/239) Scroll when afterRender
+
+## 3.0.0
+* [#238](https://github.com/DockYard/ember-router-scroll/pull/238) Upgrade ember-app-scheduler to v4.0.0
+
 ## 2.0.1
 * [#237](https://github.com/DockYard/ember-router-scroll/pull/237) Remove recursive scroll check
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -6,7 +6,6 @@ import { scheduleOnce } from '@ember/runloop';
 import { setupRouter, reset, whenRouteIdle } from 'ember-app-scheduler';
 
 let requestId;
-let REQUESTED_CALLBACK = false;
 
 // to prevent scheduleOnce calling multiple times, give it the same ref to this function
 const CALLBACK = function(transition) {
@@ -90,8 +89,6 @@ class EmberRouterScroll extends EmberRouter {
         }
       }
     }
-
-    REQUESTED_CALLBACK = false;
   }
 
   _routeWillChange() {
@@ -113,16 +110,10 @@ class EmberRouterScroll extends EmberRouter {
     if (!scrollWhenIdle && !scrollWhenAfterRender) {
       // out of the option, this happens on the tightest schedule
       scheduleOnce('render', this, CALLBACK, transition);
-    } else if (scrollWhenAfterRender) {
+    } else if (scrollWhenAfterRender && !scrollWhenIdle) {
       // out of the option, this happens on the tightest schedule
       scheduleOnce('afterRender', this, CALLBACK, transition);
     } else {
-      if (REQUESTED_CALLBACK) {
-        return;
-      }
-
-      REQUESTED_CALLBACK = true;
-
       // as described in ember-app-scheduler, this addon can be used to delay rendering until after the route is idle
       whenRouteIdle().then(() => {
         this.updateScrollPosition(transition);

--- a/addon/index.js
+++ b/addon/index.js
@@ -27,7 +27,7 @@ class CounterPool {
 
   flush() {
     if (this.counter === 0 && this.onFinishedPromise && this.onFinishedPromise.then) {
-      this.onFinishedPromise.finally(() => {
+      this.onFinishedPromise.then(() => {
         this.onFinishedCallback();
       });
     }

--- a/addon/index.js
+++ b/addon/index.js
@@ -27,6 +27,7 @@ class CounterPool {
 
   flush() {
     if (this.counter === 0 && this.onFinishedPromise && this.onFinishedPromise.then) {
+      // when we are done, attach a then callback and update scroll position
       this.onFinishedPromise.then(() => {
         this.onFinishedCallback();
       });

--- a/addon/index.js
+++ b/addon/index.js
@@ -30,7 +30,7 @@ class CounterPool {
     if (this.counter === 0 && this.onFinishedPromise && this.onFinishedPromise.then) {
       // when we are done, attach a then callback and update scroll position
       this.onFinishedPromise.then(() => {
-        this.onFinishedCallback();
+        this.onFinishedCallback && this.onFinishedCallback();
       });
     }
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -6,7 +6,6 @@ import { scheduleOnce } from '@ember/runloop';
 import { setupRouter, reset, whenRouteIdle } from 'ember-app-scheduler';
 
 let requestId;
-let IDLE_REQUESTED_CALLBACK = false;
 
 // to prevent scheduleOnce calling multiple times, give it the same ref to this function
 const CALLBACK = function(transition) {
@@ -115,15 +114,8 @@ class EmberRouterScroll extends EmberRouter {
       // out of the option, this happens on the tightest schedule
       scheduleOnce('afterRender', this, CALLBACK, transition);
     } else {
-      if (IDLE_REQUESTED_CALLBACK) {
-        return;
-      }
-
-      IDLE_REQUESTED_CALLBACK = true;
-
       // as described in ember-app-scheduler, this addon can be used to delay rendering until after the route is idle
       whenRouteIdle().then(() => {
-        IDLE_REQUESTED_CALLBACK = false;
         this.updateScrollPosition(transition);
       });
     }

--- a/addon/index.js
+++ b/addon/index.js
@@ -168,7 +168,8 @@ class EmberRouterScroll extends EmberRouter {
         this.idlePool = new CounterPool();
       }
 
-      // increments happen all in one batch (before processing flush queue)
+      // increments happen all in one batch (before processing flush queue) and happens indeterminately
+      // e.g. 4, 6, 10 times this could be called
       this.idlePool.counter = this.idlePool.counter + 1;
       this.idlePool.onFinishedPromise = whenRouteIdle();
       this.idlePool.onFinishedCallback = this.updateScrollPosition.bind(this, transition);

--- a/addon/index.js
+++ b/addon/index.js
@@ -6,6 +6,7 @@ import { scheduleOnce } from '@ember/runloop';
 import { setupRouter, reset, whenRouteIdle } from 'ember-app-scheduler';
 
 let requestId;
+let callbackRequestId;
 let idleRequestId;
 
 class CounterPool {
@@ -53,7 +54,9 @@ class CounterPool {
 
 // to prevent scheduleOnce calling multiple times, give it the same ref to this function
 const CALLBACK = function(transition) {
-  this.updateScrollPosition(transition);
+  callbackRequestId = window.requestAnimationFrame(() => {
+    this.updateScrollPosition(transition);
+  });
 }
 
 class EmberRouterScroll extends EmberRouter {
@@ -86,6 +89,10 @@ class EmberRouterScroll extends EmberRouter {
 
     if (requestId) {
       window.cancelAnimationFrame(requestId);
+    }
+
+    if (callbackRequestId) {
+      window.cancelAnimationFrame(callbackRequestId);
     }
 
     super.destroy(...arguments);

--- a/addon/index.js
+++ b/addon/index.js
@@ -53,8 +53,6 @@ class EmberRouterScroll extends EmberRouter {
    * @param {transition|transition[]} transition If before Ember 3.6, this will be an array of transitions, otherwise
    */
   updateScrollPosition(transition) {
-    IDLE_REQUESTED_CALLBACK = false;
-
     const url = get(this, 'currentURL');
     const hashElement = url ? document.getElementById(url.split('#').pop()) : null;
 
@@ -125,6 +123,7 @@ class EmberRouterScroll extends EmberRouter {
 
       // as described in ember-app-scheduler, this addon can be used to delay rendering until after the route is idle
       whenRouteIdle().then(() => {
+        IDLE_REQUESTED_CALLBACK = false;
         this.updateScrollPosition(transition);
       });
     }


### PR DESCRIPTION
`routeDidChange` is called more than once indeterminately.  `scheduleOnce` will run once IFF the same callback ref is given to it.  This PR fixes that and is the easy part of this PR.  

The **difficult** part of this PR - `whenRouteIdle` needs to be resolved and scroll position updated when we are done calling `routeDidChange`.  Effectively the last call is the last argument.  We don't want to update the scroll position somewhere in the middle.  So the difficult part of this is **when** to resolve.  We do this with `requestAnimationFrame` and a counter.

In algorithmic terms, this is a stack (and more like a deferred stack because the producer of the items does not know when it done pushing new items onto the stack.  It only attempts to pop the last item from the stack when it is done pushing new items on the stack and an arbitrary count gets back to 0).