### PR TITLE
Run service teardown code in willDestroy()

### DIFF
--- a/addon/services/router-scroll.js
+++ b/addon/services/router-scroll.js
@@ -5,7 +5,7 @@ import { assert } from '@ember/debug';
 import { getOwner } from '@ember/application';
 import { scheduleOnce } from '@ember/runloop';
 import { addListener, removeListener, sendEvent } from '@ember/object/events';
-import { setupRouter, reset, whenRouteIdle } from 'ember-app-scheduler';
+import { setupRouter, whenRouteIdle } from 'ember-app-scheduler';
 
 let ATTEMPTS = 0;
 const MAX_ATTEMPTS = 100; // rAF runs every 16ms ideally, so 60x a second
@@ -91,9 +91,7 @@ class RouterScroll extends Service {
     addListener(this.router, 'routeDidChange', this._routeDidChange);
   }
 
-  destroy() {
-    reset();
-
+  willDestroy() {
     removeListener(this.router, 'routeWillChange', this._routeWillChange);
     removeListener(this.router, 'routeDidChange', this._routeDidChange);
 
@@ -105,7 +103,7 @@ class RouterScroll extends Service {
       window.cancelAnimationFrame(callbackRequestId);
     }
 
-    super.destroy(...arguments);
+    super.willDestroy(...arguments);
   }
 
   /**


### PR DESCRIPTION
Looks like the fix made in #257 was lost during refactoring #270 (unless it was done intentionally).

See https://github.com/DockYard/ember-in-viewport/pull/241 for more details.

Additionally, removed `reset()` function call from `ember-app-scheduler` as it uses destroyable for reset, see https://github.com/ember-app-scheduler/ember-app-scheduler/blob/master/addon/scheduler.ts#L103